### PR TITLE
fix(package infos): add repository information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "keywords": [
     "effect"
   ],
+    "repository": {
+    "type": "git",
+    "url": "https://github.com/jpb06/effect-cloudflare-r2-layer.git"
+  },
   "main": "./cjs/index.js",
   "module": "./esm/index.js",
   "types": "./dts/index.d.ts",


### PR DESCRIPTION
this is used by npm to show link to repository in their sidebar

like this 
![CleanShot 2025-05-30 at 15 30 38@2x](https://github.com/user-attachments/assets/5e4fd614-76c5-4c35-8289-2090a9093017)


current
![CleanShot 2025-05-30 at 15 30 32@2x](https://github.com/user-attachments/assets/9ce46e9e-6655-4667-9057-0798166b8d5b)
